### PR TITLE
Fix main in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "develop": "done-serve --static --develop --port 8080",
     "detect-cycle": "detect-cyclic-packages --ignore done-serve"
   },
-  "main": "dist/cjs/can-log",
+  "main": "can-log",
   "keywords": [
     "canjs",
     "donejs-plugin"


### PR DESCRIPTION
The actual main in package.json `main: "dist/cjs/can-log"` throws an error: `define is not defined` if used without module loader like tests in [done-ssr](https://github.com/donejs/done-ssr/pulls).

This fixes the issue by updating `main` to the package main file `can-log.js`.